### PR TITLE
Adds workflow_job_duration_seconds and other small improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ github_actions_exporter
 # VSCode
 .vscode/
 dist/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-github_actions_exporter
+github-actions-exporter
 *.env
 *.tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ test:
 
 .PHONY: build
 build:
-	go build .
+	go build -o github-actions-exporter .

--- a/doc/webhooks.md
+++ b/doc/webhooks.md
@@ -1,5 +1,11 @@
 ## GitHub Webhooks
 
+## [Workflow Run](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_run)
+
+* Webhook field `action` is `requested` or `completed`.
+  * `requested` has `status=queued` and `conclusion=null`.
+  * `completed` can be `failure`, `success`, `cancelled`.
+
 ## [Workflow Job](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_job)
 
 * Webhook field `action` and `workflow_job[status]` are equal in webhook payloads and include `queued`, `in_progress`, `completed`

--- a/doc/webhooks.md
+++ b/doc/webhooks.md
@@ -1,0 +1,11 @@
+## GitHub Webhooks
+
+## [Workflow Job](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_job)
+
+* Webhook field `action` and `workflow_job[status]` are equal in webhook payloads and include `queued`, `in_progress`, `completed`
+* `workflow_job[conclusion]` includes but is not limited to `in_progress`, `queued`, `success`, `failure`, `cancelled`, `skipped`.
+* `workflow_job[started_at]` and `workflow_job[completed_at]` are present in all `conclusion`s that are associated with 
+  the `completed` `status` i.e `failure`, `success`, `cancelled`, `skipped`.
+
+
+

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -15,7 +15,7 @@ var (
 		Name: "workflow_job_status_count",
 		Help: "Count of the occurrences of different workflow job states.",
 	},
-		[]string{"org", "repo", "status", "runner_group"},
+		[]string{"org", "repo", "status", "conclusion", "runner_group"},
 	)
 
 	workflowRunHistogramVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -30,7 +30,7 @@ var (
 		Name: "workflow_status_count",
 		Help: "Count of the occurrences of different workflow states.",
 	},
-		[]string{"org", "repo", "workflow_name", "status"},
+		[]string{"org", "repo", "status", "conclusion", "workflow_name"},
 	)
 
 	totalMinutesUsedActions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -92,9 +92,9 @@ func init() {
 
 type WorkflowObserver interface {
 	ObserveWorkflowJobDuration(org, repo, state, runnerGroup string, seconds float64)
-	CountWorkflowJobStatus(org, repo, status, runnerGroup string)
+	CountWorkflowJobStatus(org, repo, conclusion, status, runnerGroup string)
 	ObserveWorkflowRunDuration(org, repo, workflow string, seconds float64)
-	CountWorkflowRunStatus(org, repo, workflow, status string)
+	CountWorkflowRunStatus(org, repo, conclusion, status, workflow string)
 }
 
 var _ WorkflowObserver = (*PrometheusObserver)(nil)
@@ -106,8 +106,8 @@ func (o *PrometheusObserver) ObserveWorkflowJobDuration(org, repo, state, runner
 		Observe(seconds)
 }
 
-func (o *PrometheusObserver) CountWorkflowJobStatus(org, repo, status, runnerGroup string) {
-	workflowJobStatusCounter.WithLabelValues(org, repo, status, runnerGroup).Inc()
+func (o *PrometheusObserver) CountWorkflowJobStatus(org, repo, status, conclusion, runnerGroup string) {
+	workflowJobStatusCounter.WithLabelValues(org, repo, status, conclusion, runnerGroup).Inc()
 }
 
 func (o *PrometheusObserver) ObserveWorkflowRunDuration(org, repo, workflowName string, seconds float64) {
@@ -115,6 +115,6 @@ func (o *PrometheusObserver) ObserveWorkflowRunDuration(org, repo, workflowName 
 		Observe(seconds)
 }
 
-func (o *PrometheusObserver) CountWorkflowRunStatus(org, repo, workflowName, status string) {
-	workflowRunStatusCounter.WithLabelValues(org, repo, workflowName, status).Inc()
+func (o *PrometheusObserver) CountWorkflowRunStatus(org, repo, status, conclusion, workflowName string) {
+	workflowRunStatusCounter.WithLabelValues(org, repo, status, conclusion, workflowName).Inc()
 }

--- a/internal/server/workflow_metrics_exporter.go
+++ b/internal/server/workflow_metrics_exporter.go
@@ -57,6 +57,8 @@ func (c *WorkflowMetricsExporter) HandleGHWebHook(w http.ResponseWriter, r *http
 		return
 	}
 
+	_ = level.Debug(c.Logger).Log("msg", "received webhook", "payload", string(buf))
+
 	eventType := r.Header.Get("X-GitHub-Event")
 	switch eventType {
 	case "ping":

--- a/internal/server/workflow_metrics_exporter.go
+++ b/internal/server/workflow_metrics_exporter.go
@@ -100,6 +100,11 @@ func (c *WorkflowMetricsExporter) CollectWorkflowJobEvent(event *github.Workflow
 	case "in_progress":
 		status = "in_progress"
 
+		if len(event.WorkflowJob.Steps) == 0 {
+			_ = level.Debug(c.Logger).Log("msg", "unable to calculate job duration of in_progress event as event has no steps")
+			return
+		}
+
 		firstStep := event.WorkflowJob.Steps[0]
 		queuedSeconds := firstStep.StartedAt.Time.Sub(event.WorkflowJob.StartedAt.Time).Seconds()
 		c.PrometheusObserver.ObserveWorkflowJobDuration(org, repo, "queued", runnerGroup, math.Max(0, queuedSeconds))

--- a/internal/server/workflow_metrics_exporter_test.go
+++ b/internal/server/workflow_metrics_exporter_test.go
@@ -499,6 +499,36 @@ func Test_WorkflowMetricsExporter_HandleGHWebHook_WorkflowRunEventOtherThanCompl
 	observer.assertNoWorkflowRunStatusCount(1 * time.Second)
 }
 
+func Test_WorkflowMetricsExporter_CollectWorkflowJobEvent_WorkflowJobQueuedEvent_WithNoSteps(t *testing.T) {
+	// Given
+	subject := server.WorkflowMetricsExporter{
+		Logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)),
+	}
+
+	repo := "some-repo"
+	org := "someone"
+	jobStartedAt := time.Unix(1650308740, 0)
+	runnerGroupName := "runner-group"
+	action := "in_progress"
+
+	event := github.WorkflowJobEvent{
+		Action: &action,
+		Repo: &github.Repository{
+			Name: &repo,
+			Owner: &github.User{
+				Login: &org,
+			},
+		},
+		WorkflowJob: &github.WorkflowJob{
+			StartedAt:       &github.Timestamp{Time: jobStartedAt},
+			Steps:           []*github.TaskStep{},
+			RunnerGroupName: &runnerGroupName,
+		},
+	}
+
+	subject.CollectWorkflowJobEvent(&event)
+}
+
 func testWebhookRequest(t *testing.T, url, event string, payload interface{}) *http.Request {
 	b, err := json.Marshal(payload)
 	require.NoError(t, err)

--- a/internal/server/workflow_metrics_exporter_test.go
+++ b/internal/server/workflow_metrics_exporter_test.go
@@ -123,7 +123,9 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobQueuedEvent(t *testing.T) 
 	org := "org"
 	repo := "repo"
 	runnerGroupName := "runnerGroupName"
-	action := "queued"
+	action := "completed"
+	status := "completed"
+	conclusion := "success"
 	event := github.WorkflowJobEvent{
 		Action: &action,
 		Repo: &github.Repository{
@@ -133,6 +135,8 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobQueuedEvent(t *testing.T) 
 			},
 		},
 		WorkflowJob: &github.WorkflowJob{
+			Status:          &status,
+			Conclusion:      &conclusion,
 			RunnerGroupName: &runnerGroupName,
 		},
 	}
@@ -148,8 +152,9 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobQueuedEvent(t *testing.T) 
 	observer.assertWorkflowJobStatusCount(workflowJobStatusCount{
 		org:         org,
 		repo:        repo,
-		runnerGroup: runnerGroupName,
 		status:      action,
+		conclusion:  conclusion,
+		runnerGroup: runnerGroupName,
 	}, 50*time.Millisecond)
 }
 
@@ -171,6 +176,7 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobInProgressEvent(t *testing
 	stepStartedAt := jobStartedAt.Add(time.Duration(expectedDuration) * time.Second)
 	runnerGroupName := "runner-group"
 	action := "in_progress"
+	status := "in_progress"
 
 	event := github.WorkflowJobEvent{
 		Action: &action,
@@ -181,6 +187,7 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobInProgressEvent(t *testing
 			},
 		},
 		WorkflowJob: &github.WorkflowJob{
+			Status:    &status,
 			StartedAt: &github.Timestamp{Time: jobStartedAt},
 			Steps: []*github.TaskStep{
 				{
@@ -213,6 +220,7 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobInProgressEvent(t *testing
 		repo:        repo,
 		runnerGroup: runnerGroupName,
 		status:      action,
+		conclusion:  "",
 	}, 50*time.Millisecond)
 }
 
@@ -234,6 +242,7 @@ func Test_WorkflowMetricsExporter_HandleGHWebHook_WorkflowJobInProgressEventWith
 	stepStartedAt := jobStartedAt.Add(-1 * time.Duration(expectedDuration) * time.Second)
 	runnerGroupName := "runner-group"
 	action := "in_progress"
+	status := "in_progress"
 
 	event := github.WorkflowJobEvent{
 		Action: &action,
@@ -244,6 +253,7 @@ func Test_WorkflowMetricsExporter_HandleGHWebHook_WorkflowJobInProgressEventWith
 			},
 		},
 		WorkflowJob: &github.WorkflowJob{
+			Status:    &status,
 			StartedAt: &github.Timestamp{Time: jobStartedAt},
 			Steps: []*github.TaskStep{
 				{
@@ -276,6 +286,7 @@ func Test_WorkflowMetricsExporter_HandleGHWebHook_WorkflowJobInProgressEventWith
 		repo:        repo,
 		runnerGroup: runnerGroupName,
 		status:      action,
+		conclusion:  "",
 	}, 50*time.Millisecond)
 }
 
@@ -297,10 +308,12 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobCompletedEvent(t *testing.
 	startedAt := time.Unix(1650308740, 0)
 	completedAt := startedAt.Add(time.Duration(expectedDuration) * time.Second)
 	runnerGroupName := "runner-group"
-	state := "success"
+	action := "completed"
+	status := "completed"
+	conclusion := "success"
 
 	event := github.WorkflowJobEvent{
-		Action: github.String("completed"),
+		Action: &action,
 		Repo: &github.Repository{
 			Name: &repo,
 			Owner: &github.User{
@@ -310,7 +323,8 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobCompletedEvent(t *testing.
 		WorkflowJob: &github.WorkflowJob{
 			StartedAt:       &github.Timestamp{Time: startedAt},
 			CompletedAt:     &github.Timestamp{Time: completedAt},
-			Conclusion:      &state,
+			Status:          &status,
+			Conclusion:      &conclusion,
 			RunnerGroupName: &runnerGroupName,
 		},
 	}
@@ -333,7 +347,8 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobCompletedEvent(t *testing.
 		org:         org,
 		repo:        repo,
 		runnerGroup: runnerGroupName,
-		status:      state,
+		status:      status,
+		conclusion:  conclusion,
 	}, 50*time.Millisecond)
 }
 
@@ -351,10 +366,12 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobCompletedEventWithSkippedC
 	repo := "some-repo"
 	org := "someone"
 	runnerGroupName := "runner-group"
-	state := "skipped"
+	action := "completed"
+	status := "completed"
+	conclusion := "skipped"
 
 	event := github.WorkflowJobEvent{
-		Action: github.String("completed"),
+		Action: &action,
 		Repo: &github.Repository{
 			Name: &repo,
 			Owner: &github.User{
@@ -363,7 +380,8 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobCompletedEventWithSkippedC
 		},
 		WorkflowJob: &github.WorkflowJob{
 			StartedAt:       nil,
-			Conclusion:      &state,
+			Status:          &status,
+			Conclusion:      &conclusion,
 			Steps:           []*github.TaskStep{},
 			RunnerGroupName: &runnerGroupName,
 		},
@@ -381,7 +399,8 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobCompletedEventWithSkippedC
 		org:         org,
 		repo:        repo,
 		runnerGroup: runnerGroupName,
-		status:      state,
+		status:      status,
+		conclusion:  conclusion,
 	}, 50*time.Millisecond)
 }
 
@@ -400,10 +419,12 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobCompletedEvent_WithNoStart
 	org := "someone"
 
 	runnerGroupName := "runner-group"
-	state := "success"
+	action := "completed"
+	status := "completed"
+	conclusion := "success"
 
 	event := github.WorkflowJobEvent{
-		Action: github.String("completed"),
+		Action: &action,
 		Repo: &github.Repository{
 			Name: &repo,
 			Owner: &github.User{
@@ -412,7 +433,8 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobCompletedEvent_WithNoStart
 		},
 		WorkflowJob: &github.WorkflowJob{
 			CompletedAt:     &github.Timestamp{Time: time.Unix(1650308740, 0)},
-			Conclusion:      &state,
+			Conclusion:      &conclusion,
+			Status:          &status,
 			RunnerGroupName: &runnerGroupName,
 		},
 	}
@@ -428,7 +450,8 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobCompletedEvent_WithNoStart
 		org:         org,
 		repo:        repo,
 		runnerGroup: runnerGroupName,
-		status:      state,
+		status:      status,
+		conclusion:  conclusion,
 	}, 50*time.Millisecond)
 }
 
@@ -446,10 +469,12 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobCompletedEvent_WithNoCompl
 	repo := "some-repo"
 	org := "someone"
 	runnerGroupName := "runner-group"
-	state := "success"
+	action := "completed"
+	status := "completed"
+	conclusion := "success"
 
 	event := github.WorkflowJobEvent{
-		Action: github.String("completed"),
+		Action: &action,
 		Repo: &github.Repository{
 			Name: &repo,
 			Owner: &github.User{
@@ -458,7 +483,8 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobCompletedEvent_WithNoCompl
 		},
 		WorkflowJob: &github.WorkflowJob{
 			StartedAt:       &github.Timestamp{Time: time.Unix(1650308740, 0)},
-			Conclusion:      &state,
+			Conclusion:      &conclusion,
+			Status:          &status,
 			RunnerGroupName: &runnerGroupName,
 		},
 	}
@@ -474,7 +500,8 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobCompletedEvent_WithNoCompl
 		org:         org,
 		repo:        repo,
 		runnerGroup: runnerGroupName,
-		status:      state,
+		status:      status,
+		conclusion:  conclusion,
 	}, 50*time.Millisecond)
 }
 
@@ -606,7 +633,7 @@ type workflowJobObservation struct {
 	seconds                       float64
 }
 type workflowJobStatusCount struct {
-	org, repo, runnerGroup, status string
+	org, repo, status, conclusion, runnerGroup string
 }
 
 type workflowRunObservation struct {
@@ -615,7 +642,7 @@ type workflowRunObservation struct {
 }
 
 type workflowRunStatusCount struct {
-	org, repo, workflowName, status string
+	org, repo, status, conclusion, workflowName string
 }
 
 var _ server.WorkflowObserver = (*TestPrometheusObserver)(nil)
@@ -648,12 +675,13 @@ func (o *TestPrometheusObserver) ObserveWorkflowJobDuration(org, repo, state, ru
 	}
 }
 
-func (o *TestPrometheusObserver) CountWorkflowJobStatus(org, repo, status, runnerGroup string) {
+func (o *TestPrometheusObserver) CountWorkflowJobStatus(org, repo, status, conclusion, runnerGroup string) {
 	o.workflowJobStatusCounted <- workflowJobStatusCount{
 		org:         org,
 		repo:        repo,
-		runnerGroup: runnerGroup,
 		status:      status,
+		conclusion:  conclusion,
+		runnerGroup: runnerGroup,
 	}
 }
 
@@ -666,12 +694,13 @@ func (o *TestPrometheusObserver) ObserveWorkflowRunDuration(org, repo, workflowN
 	}
 }
 
-func (o *TestPrometheusObserver) CountWorkflowRunStatus(org, repo, workflowName, status string) {
+func (o *TestPrometheusObserver) CountWorkflowRunStatus(org, repo, status, conclusion, workflowName string) {
 	o.workflowRunStatusCounted <- workflowRunStatusCount{
 		org:          org,
 		repo:         repo,
-		workflowName: workflowName,
 		status:       status,
+		conclusion:   conclusion,
+		workflowName: workflowName,
 	}
 }
 


### PR DESCRIPTION

Adds workflow_job_duration_seconds - a counter of the total usage for a given owner, repo, status, conclusion, runnerGroup. This allows for a more accurate view of the total seconds usage. Note that this is not fully equivalent to billed usage, as GitHub rounds up to the minute. That could be an additional metric.

Other improvements
* Workflow job metrics now have `status` + `conclusion` labels. Previously, these metrics had a single status label that contained either the status, or conclusion event field, depending on the event type. Now, the following questions are asked like:
    *  "What is the duration for all completed events?" - `status=completed`
    * "What is the duration for all successful events?" - `status=completed`, `conclusion=success`
* Improves reliability of `workflow_job_duration_seconds`. GitHub does occasionally send strange completed events without all the steps shown in the UI. This makes the previous implementation inaccurate. This is now calculated from workflow_job StartedAt + Concluded at timestamps instead of using the step timestamps. From my observations these are always present.
* Adds .idea dir to .gitignore
* Handles body read error
* Adds documentation page on webhook assumptions
* Handles in_progress events with no steps without panic
* Updates binary generated from Makefile so the Dockerfile runs locally (it expects this name)
* Adds debug logging of event payload - this was incredibly helpful for understanding event composition and making some of the above changes