### PR TITLE
add actions_total_minutes_used_by_host_minutes metric

### DIFF
--- a/internal/server/billing_metrics_exporter.go
+++ b/internal/server/billing_metrics_exporter.go
@@ -92,6 +92,12 @@ func (c *BillingMetricsExporter) collectOrgBilling(ctx context.Context) {
 	totalMinutesUsedActions.WithLabelValues(c.Opts.GitHubOrg, "").Set(actionsBilling.TotalMinutesUsed)
 	includedMinutesUsedActions.WithLabelValues(c.Opts.GitHubOrg, "").Set(actionsBilling.IncludedMinutes)
 	totalPaidMinutesActions.WithLabelValues(c.Opts.GitHubOrg, "").Set(actionsBilling.TotalPaidMinutesUsed)
+
+	for host, minutes := range actionsBilling.MinutesUsedBreakdown {
+		totalMinutesUsedByHostTypeActions.WithLabelValues(c.Opts.GitHubOrg, "", host).Set(float64(minutes))
+	}
+
+	// TODO: deprecate
 	totalMinutesUsedUbuntuActions.WithLabelValues(c.Opts.GitHubOrg, "").Set(float64(actionsBilling.MinutesUsedBreakdown["UBUNTU"]))
 	totalMinutesUsedMacOSActions.WithLabelValues(c.Opts.GitHubOrg, "").Set(float64(actionsBilling.MinutesUsedBreakdown["MACOS"]))
 	totalMinutesUsedWindowsActions.WithLabelValues(c.Opts.GitHubOrg, "").Set(float64(actionsBilling.MinutesUsedBreakdown["WINDOWS"]))
@@ -107,6 +113,12 @@ func (c *BillingMetricsExporter) collectUserBilling(ctx context.Context) {
 	totalMinutesUsedActions.WithLabelValues("", c.Opts.GitHubUser).Set(actionsBilling.TotalMinutesUsed)
 	includedMinutesUsedActions.WithLabelValues("", c.Opts.GitHubUser).Set(actionsBilling.IncludedMinutes)
 	totalPaidMinutesActions.WithLabelValues("", c.Opts.GitHubUser).Set(actionsBilling.TotalPaidMinutesUsed)
+
+	for host, minutes := range actionsBilling.MinutesUsedBreakdown {
+		totalMinutesUsedByHostTypeActions.WithLabelValues("", c.Opts.GitHubUser, host).Set(float64(minutes))
+	}
+
+	// TODO: deprecate
 	totalMinutesUsedUbuntuActions.WithLabelValues("", c.Opts.GitHubUser).Set(float64(actionsBilling.MinutesUsedBreakdown["UBUNTU"]))
 	totalMinutesUsedMacOSActions.WithLabelValues("", c.Opts.GitHubUser).Set(float64(actionsBilling.MinutesUsedBreakdown["MACOS"]))
 	totalMinutesUsedWindowsActions.WithLabelValues("", c.Opts.GitHubUser).Set(float64(actionsBilling.MinutesUsedBreakdown["WINDOWS"]))

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -63,23 +63,30 @@ var (
 
 	totalMinutesUsedUbuntuActions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "actions_total_minutes_used_ubuntu_minutes",
-		Help: "Total minutes used for Ubuntu type for the GitHub Actions.",
+		Help: "Total minutes used for Ubuntu type for the GitHub Actions. To be deprecate, use actions_total_minutes_used_by_host_minutes",
 	},
 		[]string{"org", "user"},
 	)
 
 	totalMinutesUsedMacOSActions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "actions_total_minutes_used_macos_minutes",
-		Help: "Total minutes used for MacOS type for the GitHub Actions.",
+		Help: "Total minutes used for MacOS type for the GitHub Actions. To be deprecate, use actions_total_minutes_used_by_host_minutes",
 	},
 		[]string{"org", "user"},
 	)
 
 	totalMinutesUsedWindowsActions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "actions_total_minutes_used_windows_minutes",
-		Help: "Total minutes used for Windows type for the GitHub Actions.",
+		Help: "Total minutes used for Windows type for the GitHub Actions. To be deprecate, use actions_total_minutes_used_by_host_minutes",
 	},
 		[]string{"org", "user"},
+	)
+
+	totalMinutesUsedByHostTypeActions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "actions_total_minutes_used_by_host_minutes",
+		Help: "Total minutes used for a specific host type for the GitHub Actions.",
+	},
+		[]string{"org", "user", "host_type"},
 	)
 )
 
@@ -96,6 +103,7 @@ func init() {
 	prometheus.MustRegister(totalMinutesUsedUbuntuActions)
 	prometheus.MustRegister(totalMinutesUsedMacOSActions)
 	prometheus.MustRegister(totalMinutesUsedWindowsActions)
+	prometheus.MustRegister(totalMinutesUsedByHostTypeActions)
 }
 
 type WorkflowObserver interface {


### PR DESCRIPTION
now github add other types of host like

```json
{
  "total_minutes_used": 0,
  "total_paid_minutes_used": 0,
  "included_minutes": 50000.0,
  "minutes_used_breakdown": {
    "UBUNTU": 0,
    "MACOS": 0,
    "WINDOWS": 0,
    "ubuntu_4_core": 0,
    "ubuntu_8_core": 0,
    "ubuntu_16_core": 0,
    "ubuntu_32_core": 0,
    "ubuntu_64_core": 0,
    "windows_4_core": 0,
    "windows_8_core": 0,
    "windows_16_core": 0,
    "windows_32_core": 0,
    "windows_64_core": 0,
    "macos_12_core": 0,
    "total": 0
  }
}
```