### PR TITLE
Fix GITHUB_API_TOKEN naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ make build
 ## Run the binary
 
 ```bash
-./github_actions_exporter --gh.github-webhook-token="MY_TOKEN" --gh.github-api-token="Accesstoken" --gh.github-org="honk_org"
+./github_actions_exporter --gh.github-webhook-token="MY_TOKEN" --gh.github-token="Accesstoken" --gh.github-org="honk_org"
 ```
 
 ## Docker
@@ -58,7 +58,7 @@ For example:
 
 ```bash
 docker pull ghcr.io/cpanato/github_actions_exporter-linux-amd64:v0.2.0
-docker run -d -p 9101:9101 ghcr.io/cpanato/github_actions_exporter-linux-amd64:v0.2.0 --gh.github-webhook-token="1234567890token" --gh.github-api-token="Accesstoken" --gh.github-org="honk_org"
+docker run -d -p 9101:9101 ghcr.io/cpanato/github_actions_exporter-linux-amd64:v0.2.0 --gh.github-webhook-token="1234567890token" --gh.github-token="Accesstoken" --gh.github-org="honk_org"
 ```
 
 ## Testing
@@ -74,7 +74,7 @@ make test
 ```bash
 cd example/
 export GITHUB_WEBHOOK_TOKEN="..."
-export GITHUB_API_TOKEN="..."
+export GITHUB_TOKEN="..."
 export GITHUB_ORG="..."
 docker-compose up --build
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ make test
 ```bash
 cd example/
 export GITHUB_WEBHOOK_TOKEN="..."
-export GITHUB_TOKEN="..."
+export GITHUB_API_TOKEN="..."
 export GITHUB_ORG="..."
 docker-compose up --build
 ```

--- a/charts/github-exporter/Chart.yaml
+++ b/charts/github-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: GitHub exporter
 name: github-exporter
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.7.1
 home: https://github.com/cpanato/github_actions_exporter
 maintainers:

--- a/charts/github-exporter/templates/deployment.yaml
+++ b/charts/github-exporter/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}@{{ .Values.deployment.image.digest }}"
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           args:
-          - --gh.github-api-token=$(GITHUB_API_TOKEN)
+          - --gh.github-token=$(GITHUB_TOKEN)
           - --gh.github-webhook-token=$(GITHUB_WEBHOOK_TOKEN)
           - --gh.github-org={{ .Values.config.org }}
           - --gh.billing-poll-seconds={{ .Values.config.pollSeconds }}

--- a/charts/github-exporter/templates/deployment.yaml
+++ b/charts/github-exporter/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}@{{ .Values.deployment.image.digest }}"
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           args:
-          - --gh.github-token=$(GITHUB_TOKEN)
+          - --gh.github-api-token=$(GITHUB_TOKEN)
           - --gh.github-webhook-token=$(GITHUB_WEBHOOK_TOKEN)
           - --gh.github-org={{ .Values.config.org }}
           - --gh.billing-poll-seconds={{ .Values.config.pollSeconds }}

--- a/charts/github-exporter/templates/deployment.yaml
+++ b/charts/github-exporter/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}@{{ .Values.deployment.image.digest }}"
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           args:
-          - --gh.github-api-token=$(GITHUB_TOKEN)
+          - --gh.github-api-token=$(GITHUB_API_TOKEN)
           - --gh.github-webhook-token=$(GITHUB_WEBHOOK_TOKEN)
           - --gh.github-org={{ .Values.config.org }}
           - --gh.billing-poll-seconds={{ .Values.config.pollSeconds }}

--- a/charts/github-exporter/templates/secret.yaml
+++ b/charts/github-exporter/templates/secret.yaml
@@ -13,7 +13,7 @@ metadata:
   name: {{ include "github-exporter.fullname" . }}
   namespace: {{ .Release.Namespace }}
 data:
-  GITHUB_API_TOKEN: {{ .Values.secret.githubToken | b64enc }}
+  GITHUB_TOKEN: {{ .Values.secret.githubToken | b64enc }}
   GITHUB_WEBHOOK_TOKEN: {{ .Values.secret.githubWebhookToken | b64enc }}
 type: Opaque
 {{- end }}

--- a/charts/github-exporter/templates/secret.yaml
+++ b/charts/github-exporter/templates/secret.yaml
@@ -13,7 +13,7 @@ metadata:
   name: {{ include "github-exporter.fullname" . }}
   namespace: {{ .Release.Namespace }}
 data:
-  GITHUB_TOKEN: {{ .Values.secret.githubToken | b64enc }}
+  GITHUB_API_TOKEN: {{ .Values.secret.githubToken | b64enc }}
   GITHUB_WEBHOOK_TOKEN: {{ .Values.secret.githubWebhookToken | b64enc }}
 type: Opaque
 {{- end }}

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: example/Dockerfile.dev
     command:
       - "--gh.github-webhook-token=$WEBHOOK_SECRET"
-      - "--gh.github-api-token=$GITHUB_TOKEN"
+      - "--gh.github-api-token=$GITHUB_API_TOKEN"
       - "--gh.github-org=$GITHUB_ORG"
     ports:
       - 9101:9101

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: example/Dockerfile.dev
     command:
       - "--gh.github-webhook-token=$WEBHOOK_SECRET"
-      - "--gh.github-token=$GITHUB_TOKEN"
+      - "--gh.github-token=$GITHUB_API_TOKEN"
       - "--gh.github-org=$GITHUB_ORG"
     ports:
       - 9101:9101

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: example/Dockerfile.dev
     command:
       - "--gh.github-webhook-token=$WEBHOOK_SECRET"
-      - "--gh.github-api-token=$GITHUB_API_TOKEN"
+      - "--gh.github-token=$GITHUB_TOKEN"
       - "--gh.github-org=$GITHUB_ORG"
     ports:
       - 9101:9101

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ var (
 	metricsPath                 = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 	ghWebHookPath               = kingpin.Flag("web.gh-webhook-path", "Path that will be called by the GitHub webhook.").Default("/gh_event").String()
 	githubWebhookToken          = kingpin.Flag("gh.github-webhook-token", "GitHub Webhook Token.").Envar("GITHUB_WEBHOOK_TOKEN").Default("").String()
-	gitHubAPIToken              = kingpin.Flag("gh.github-api-token", "GitHub API Token.").Envar("GITHUB_API_TOKEN").Default("").String()
+	gitHubAPIToken              = kingpin.Flag("gh.github-token", "GitHub API Token.").Envar("GITHUB_TOKEN").Default("").String()
 	gitHubOrg                   = kingpin.Flag("gh.github-org", "GitHub Organization.").Envar("GITHUB_ORG").Default("").String()
 	gitHubUser                  = kingpin.Flag("gh.github-user", "GitHub User.").Default("").String()
 	gitHubBillingPollingSeconds = kingpin.Flag("gh.billing-poll-seconds", "Frequency at which to poll billing API.").Default("5").Int()

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ var (
 	metricsPath                 = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 	ghWebHookPath               = kingpin.Flag("web.gh-webhook-path", "Path that will be called by the GitHub webhook.").Default("/gh_event").String()
 	githubWebhookToken          = kingpin.Flag("gh.github-webhook-token", "GitHub Webhook Token.").Envar("GITHUB_WEBHOOK_TOKEN").Default("").String()
-	gitHubAPIToken              = kingpin.Flag("gh.github-token", "GitHub API Token.").Envar("GITHUB_TOKEN").Default("").String()
+	gitHubAPIToken              = kingpin.Flag("gh.github-token", "GitHub API Token.").Envar("GITHUB_API_TOKEN").Default("").String()
 	gitHubOrg                   = kingpin.Flag("gh.github-org", "GitHub Organization.").Envar("GITHUB_ORG").Default("").String()
 	gitHubUser                  = kingpin.Flag("gh.github-user", "GitHub User.").Default("").String()
 	gitHubBillingPollingSeconds = kingpin.Flag("gh.billing-poll-seconds", "Frequency at which to poll billing API.").Default("5").Int()


### PR DESCRIPTION
I believe the environment variable `GITHUB_API_TOKEN` should be updated here as well after my [previous PR](https://github.com/cpanato/github_actions_exporter/pull/161).

I've found other references to `GITHUB_TOKEN` in the project, but I'm not 100% sure if they should be also updated.