### PR TITLE
Fix queued time observation

### DIFF
--- a/internal/server/workflow_metrics_exporter.go
+++ b/internal/server/workflow_metrics_exporter.go
@@ -120,6 +120,12 @@ func (c *WorkflowMetricsExporter) CollectWorkflowJobEvent(event *github.Workflow
 			break
 		}
 
+		if len(workflowJob.Steps) > 1 {
+			// If there are more than one steps, we are receiving an update of an already running job.
+			// Don't count the queued time again since it's already running.
+			break
+		}
+
 		firstStep := workflowJob.Steps[0]
 		queuedSeconds := firstStep.StartedAt.Time.Sub(workflowJob.GetStartedAt().Time).Seconds()
 		c.PrometheusObserver.ObserveWorkflowJobDuration(org, repo, branch, "queued", runnerGroup, workflowName, jobName, math.Max(0, queuedSeconds))

--- a/internal/server/workflow_metrics_exporter_test.go
+++ b/internal/server/workflow_metrics_exporter_test.go
@@ -203,7 +203,7 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobInProgressEventFirstStep(t
 			Steps: []*github.TaskStep{
 				{
 					StartedAt: &github.Timestamp{Time: stepStartedAt},
-					Status: &statusInProgress,
+					Status:    &statusInProgress,
 				},
 			},
 			RunnerGroupName: &runnerGroupName,
@@ -280,11 +280,11 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobInProgressEventSecondStep(
 			Steps: []*github.TaskStep{
 				{
 					StartedAt: &github.Timestamp{Time: stepStartedAt},
-					Status: &statusCompleted,
+					Status:    &statusCompleted,
 				},
 				{
 					StartedAt: &github.Timestamp{Time: stepStartedAt.Add(5 * time.Second)},
-					Status: &statusInProgress,
+					Status:    &statusInProgress,
 				},
 			},
 			RunnerGroupName: &runnerGroupName,
@@ -300,7 +300,7 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobInProgressEventSecondStep(
 
 	// Then
 	assert.Equal(t, http.StatusAccepted, res.Result().StatusCode)
-	observer.assertNoWorkflowJobDurationObservation(50*time.Millisecond)
+	observer.assertNoWorkflowJobDurationObservation(50 * time.Millisecond)
 	observer.assertWorkflowJobStatusCount(workflowJobStatusCount{
 		org:          org,
 		repo:         repo,

--- a/internal/server/workflow_metrics_exporter_test.go
+++ b/internal/server/workflow_metrics_exporter_test.go
@@ -165,7 +165,7 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobQueuedEvent(t *testing.T) 
 	}, 50*time.Millisecond)
 }
 
-func Test_GHActionExporter_HandleGHWebHook_WorkflowJobInProgressEvent(t *testing.T) {
+func Test_GHActionExporter_HandleGHWebHook_WorkflowJobInProgressEventFirstStep(t *testing.T) {
 	// Given
 	observer := NewTestPrometheusObserver(t)
 	subject := server.WorkflowMetricsExporter{
@@ -184,7 +184,7 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobInProgressEvent(t *testing
 	stepStartedAt := jobStartedAt.Add(time.Duration(expectedDuration) * time.Second)
 	runnerGroupName := "runner-group"
 	action := "in_progress"
-	status := "in_progress"
+	statusInProgress := "in_progress"
 	workflowName := "Build and test"
 	jobName := "Test"
 
@@ -198,14 +198,12 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobInProgressEvent(t *testing
 		},
 		WorkflowJob: &github.WorkflowJob{
 			HeadBranch: &branch,
-			Status:     &status,
+			Status:     &statusInProgress,
 			StartedAt:  &github.Timestamp{Time: jobStartedAt},
 			Steps: []*github.TaskStep{
 				{
 					StartedAt: &github.Timestamp{Time: stepStartedAt},
-				},
-				{
-					StartedAt: &github.Timestamp{Time: stepStartedAt.Add(5 * time.Second)},
+					Status: &statusInProgress,
 				},
 			},
 			RunnerGroupName: &runnerGroupName,
@@ -231,6 +229,78 @@ func Test_GHActionExporter_HandleGHWebHook_WorkflowJobInProgressEvent(t *testing
 		workflowName: workflowName,
 		jobName:      jobName,
 	}, 50*time.Millisecond)
+	observer.assertWorkflowJobStatusCount(workflowJobStatusCount{
+		org:          org,
+		repo:         repo,
+		branch:       branch,
+		runnerGroup:  runnerGroupName,
+		status:       action,
+		conclusion:   "",
+		workflowName: workflowName,
+		jobName:      jobName,
+	}, 50*time.Millisecond)
+}
+
+func Test_GHActionExporter_HandleGHWebHook_WorkflowJobInProgressEventSecondStep(t *testing.T) {
+	// Given
+	observer := NewTestPrometheusObserver(t)
+	subject := server.WorkflowMetricsExporter{
+		Logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)),
+		Opts: server.Opts{
+			GitHubToken: webhookSecret,
+		},
+		PrometheusObserver: observer,
+	}
+
+	repo := "some-repo"
+	org := "someone"
+	branch := "some-branch"
+	expectedDuration := 10.0
+	jobStartedAt := time.Unix(1650308740, 0)
+	stepStartedAt := jobStartedAt.Add(time.Duration(expectedDuration) * time.Second)
+	runnerGroupName := "runner-group"
+	action := "in_progress"
+	statusInProgress := "in_progress"
+	statusCompleted := "completed"
+	workflowName := "Build and test"
+	jobName := "Test"
+
+	event := github.WorkflowJobEvent{
+		Action: &action,
+		Repo: &github.Repository{
+			Name: &repo,
+			Owner: &github.User{
+				Login: &org,
+			},
+		},
+		WorkflowJob: &github.WorkflowJob{
+			HeadBranch: &branch,
+			Status:     &statusInProgress,
+			StartedAt:  &github.Timestamp{Time: jobStartedAt},
+			Steps: []*github.TaskStep{
+				{
+					StartedAt: &github.Timestamp{Time: stepStartedAt},
+					Status: &statusCompleted,
+				},
+				{
+					StartedAt: &github.Timestamp{Time: stepStartedAt.Add(5 * time.Second)},
+					Status: &statusInProgress,
+				},
+			},
+			RunnerGroupName: &runnerGroupName,
+			WorkflowName:    &workflowName,
+			Name:            &jobName,
+		},
+	}
+	req := testWebhookRequest(t, "/anything", "workflow_job", event)
+
+	// When
+	res := httptest.NewRecorder()
+	subject.HandleGHWebHook(res, req)
+
+	// Then
+	assert.Equal(t, http.StatusAccepted, res.Result().StatusCode)
+	observer.assertNoWorkflowJobDurationObservation(50*time.Millisecond)
 	observer.assertWorkflowJobStatusCount(workflowJobStatusCount{
 		org:          org,
 		repo:         repo,
@@ -281,9 +351,6 @@ func Test_WorkflowMetricsExporter_HandleGHWebHook_WorkflowJobInProgressEventWith
 			Steps: []*github.TaskStep{
 				{
 					StartedAt: &github.Timestamp{Time: stepStartedAt},
-				},
-				{
-					StartedAt: &github.Timestamp{Time: stepStartedAt.Add(5 * time.Second)},
 				},
 			},
 			RunnerGroupName: &runnerGroupName,


### PR DESCRIPTION
I believe the metric is a bit skewed right now. We observe the queued time n times per job, where n == amount of steps.
This puts more weight on jobs with many steps.

This PR changes it, such that we only observe once per job.